### PR TITLE
Fix compile error[E0308] (mismatched types) on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ fn main() {
         set.insert((entry.dev(), entry.ino()))
     }
     #[cfg(not(unix))]
-    fn check_inode(_: &mut HashSet<(u64, u64)>, _: &Vec<()>) -> bool {
+    fn check_inode(_: &mut HashSet<(u64, u64)>, _: &Metadata) -> bool {
         true
     }
 


### PR DESCRIPTION
After birkenfeld/fddf@742ade72e1e6291dea38a9df170532cc15c0cf4e,
fddf won't compile on Windows with the following error message:

```
error[E0308]: mismatched types
   --> src\main.rs:306:69
    |
306 | ...                   if check_inode(&mut inodes, &meta) {
    |                                                   ^^^^^ expected struct `std::vec::Vec`, found struct `std::fs::Metadata`
    |
    = note: expected type `&std::vec::Vec<()>`
               found type `&std::fs::Metadata`
```